### PR TITLE
Pin elasticsearch to version 1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,8 @@ dockerfiles
 Collection of dockerfiles we use at Aexea
 
 See also: https://github.com/aexeagmbh/docker-aexea-base
+
+
+### Elastic Search
+[![](https://badge.imagelayers.io/aexea/elasticsearch:latest.svg)](https://imagelayers.io/?images=aexea/elasticsearch:latest 'Get your own badge on imagelayers.io')
+[![ImageLayers Size](https://img.shields.io/imagelayers/image-size/aexea/elasticsearch/latest.svg)](https://www.ax-semantics.com/)

--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -1,4 +1,4 @@
-FROM elasticsearch
+FROM elasticsearch:1.5
 MAINTAINER Aexea Carpentry
 
 ADD elasticsearch.yml /usr/share/elasticsearch/config/elasticsearch.yml


### PR DESCRIPTION
Production uses 1.5 and not 2.2 and we should use the same version everywhere.

Regards aexeagmbh/ax#6